### PR TITLE
added setting _DROP_INDEXES to drop existing indexes

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -33,6 +33,12 @@ _CHUNK_SIZE = 5000
 _NODES = 5
 _THREADING_ENABLED = True
 
+# drop indexes?  Setting this to 'true' will drop any existing indexes in the
+# database.  This is most likely desirable, as bulk upserts should be faster
+# without any indexes on the collection.  However, it is important to remember
+# to then build the indexes through grits_ensure_index.py
+_DROP_INDEXES = True
+
 # default command-line options
 # Allow environment variables for MONGO_HOST, MONGO_DATABASE, MONGO_USERNAME,
 # and MONGO_PASSWORD to override these settings

--- a/tools/grits_mongo.py
+++ b/tools/grits_mongo.py
@@ -29,6 +29,8 @@ class GritsMongoConnection(object):
         self._database = program_arguments.database
         self._client = None
         self._db = self.connect()
+        if settings._DROP_INDEXES:
+            self.drop_indexes()
 
     def connect(self):
         """ connect to mongoDB
@@ -44,6 +46,13 @@ class GritsMongoConnection(object):
                 (self._hostname, self._database)
         self._client = pymongo.MongoClient(uri)
         return pymongo.database.Database(self._client, self._database)
+
+    def drop_indexes(self):
+        """ drops any existing indexes"""
+        airports = pymongo.collection.Collection(self._db, settings._AIRPORT_COLLECTION_NAME)
+        airports.drop_indexes()
+        flights = pymongo.collection.Collection(self._db, settings._FLIGHT_COLLECTION_NAME)
+        flights.drop_indexes()
 
     def ensure_indexes(self, *args):
         """ creates indexes on the collections if they do not exist """


### PR DESCRIPTION
PT #112142309 - Update grits_ensure_indexes.py to drop existing indexes before creating indexes
